### PR TITLE
3 Implement ALKiln GitHub sandbox tests , and 2 Strengthen the logic for showing specific dev output 

### DIFF
--- a/.github/workflows/run_form_tests.yml
+++ b/.github/workflows/run_form_tests.yml
@@ -5,37 +5,51 @@ on:
   workflow_dispatch:
     inputs:
       tags:
-        description: 'Optional. Use a "tag expression" specify which tagged tests to run. See https://cucumber.io/docs/cucumber/api/#tag-expressions for syntax.'
-        default: ''
-  # To run your tests on a schedule, delete the first "#" symbol at the beginning of each line below.
-  ## Also see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
-  ## Also see https://crontab.guru/examples.html
-  #schedule:
-  #  - cron: '0 1 * * TUE'
+        required: False
+        description: 'Optional. Use a "tag expression" specify which tagged tests to run (https://cucumber.io/docs/cucumber/api/#tag-expressions)'
+      # `show_docker_output` is an experimental ALKiln feature
+      show_docker_output:
+        required: false
+        default: false
+        type: boolean
+        description: 'Experimental feature. Show the docker logs while building the GitHub server container. It will also save the docker log artifact. This might show sensitive config information.'
+      # To run your tests on a schedule, delete the first "#" symbol at the beginning of each line below.
+      ## Also see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+      ## Also see https://crontab.guru/examples.html
+      #schedule:
+      #  - cron: '0 1 * * TUE'
 
 jobs:
 
-  interview-testing:
+  alkiln-github-tests:
     runs-on: ubuntu-latest
-    name: Run interview tests
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use ALKiln to run tests
-        uses: SuffolkLITLab/ALKiln@v5
-        with:
-          SERVER_URL: "${{ secrets.SERVER_URL }}"
-          DOCASSEMBLE_DEVELOPER_API_KEY: "${{ secrets.DOCASSEMBLE_DEVELOPER_API_KEY }}"
-      - run: echo "Finished running ALKiln tests"
+    strategy:
+      matrix:
+        node-version: [20.x]
       
-      ## To make a new issue in your repository when a test fails,
-      ## simply delete the first "#" symbol in each line below
-      #- name: If any tests failed create an issue
-      #  if: ${{ failure() }}
-      #  uses: actions-ecosystem/action-create-issue@v1
-      #  with:
-      #    github_token: "${{ secrets.github_token }}"
-      #    title: ALKiln tests failed
-      #    body: |
-      #      An ALKiln test failed. See the action at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
-      #    labels: |
-      #      bug
+    steps:
+      # Place the root directory in this branch to access relative paths to action files
+      - uses: actions/checkout@v4
+
+      - name: "ALKiln - Start the isolated temporary docassemble server on GitHub"
+        id: github_server
+        uses: suffolkLITLab/ALKiln/action_for_github_server@v5
+        with:
+          SHOW_DOCKER_OUTPUT: "${{ github.event.inputs.show_docker_output }}"
+          CONFIG_CONTENTS: "${{ secrets.CONFIG_CONTENTS }}"
+      - run: echo "ALKiln finished starting the isolated GitHub docassemble server"
+        shell: bash
+
+      - name: "Run ALKiln tests"
+        if: ${{ success() }}
+        id: alkiln
+        uses: suffolkLITLab/ALKiln@v5
+        with:
+          # Required inputs. See https://assemblyline.suffolklitlab.org/docs/alkiln/writing/#sandbox-inputs
+          SERVER_URL: "${{ steps.github_server.outputs.SERVER_URL }}"
+          DOCASSEMBLE_DEVELOPER_API_KEY: "${{ steps.github_server.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}"
+          INSTALL_METHOD: "server"
+          # To learn more about these optional inputs, see
+          # https://assemblyline.suffolklitlab.org/docs/alkiln/writing/#optional-inputs
+          # ALKILN_TAG_EXPRESSION: "${{ env.ALKILN_TAG_EXPRESSION }}"
+          # ALKILN_VERSION: ""


### PR DESCRIPTION
Step 3. Now the tests will run on a server GitHub creates. They won't affect A2JatAKCourts servers at all. The documentation for these is sparse and lacking simple explanations right now, but it's at https://assemblyline.suffolklitlab.org/docs/components/ALKiln/setup/#sandbox-how-to

Step 2. This will make testing easier. For example, testing on an isolated GitHub server with ALKiln should now be possible.